### PR TITLE
remove application subelements that can block Manifest merge

### DIFF
--- a/ahbottomnavigation/src/main/AndroidManifest.xml
+++ b/ahbottomnavigation/src/main/AndroidManifest.xml
@@ -2,11 +2,6 @@
           xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true"
-        >
-
-    </application>
+        />
 
 </manifest>

--- a/ahbottomnavigation/src/main/res/values/strings.xml
+++ b/ahbottomnavigation/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">AHBottomNavigation</string>
-</resources>


### PR DESCRIPTION
Removed unnecessary subelements from application declaration in library because they can block compilation.

For example, I have `android:allowBackup="false"`, so manifest merge failed since the library said `true`.