### PR TITLE
Fix setCurrentItem

### DIFF
--- a/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
+++ b/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
@@ -791,15 +791,13 @@ public class AHBottomNavigation extends FrameLayout {
 			Log.w(TAG, "The position is out of bounds of the items (" + items.size() + " elements)");
 			return;
 		}
-		if (views.size() == 0) {
-			currentItem = position;
+
+		if (items.size() == MIN_ITEMS || forceTitlesDisplay) {
+			updateItems(position, useCallback);
 		} else {
-			if (items.size() == MIN_ITEMS || forceTitlesDisplay) {
-				updateItems(position, useCallback);
-			} else {
-				updateSmallItems(position, useCallback);
-			}
+			updateSmallItems(position, useCallback);
 		}
+
 	}
 
 	/**


### PR DESCRIPTION
onTabSelected is not triggered if you call setCurrentItem in Activity's onCreate method (need to restore the selected tab after screen rotation).

I think it's because this happens before the view is measured, AHBottomNavigationItems haven't been created, views.size() is 0.

Is there a specific reason to do this view.size() checking? I feel it's safe to remove it.