### PR TITLE
Show backgroundColorView while performing the circular reveal, hide it when finished

### DIFF
--- a/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
+++ b/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
@@ -482,10 +482,12 @@ public class AHBottomNavigation extends FrameLayout {
 					anim.addListener(new Animator.AnimatorListener() {
 						@Override
 						public void onAnimationStart(Animator animation) {
+							backgroundColorView.setVisibility(VISIBLE);
 						}
 
 						@Override
 						public void onAnimationEnd(Animator animation) {
+							backgroundColorView.setVisibility(INVISIBLE);
 							setBackgroundColor(items.get(itemIndex).getColor(context));
 						}
 
@@ -588,10 +590,12 @@ public class AHBottomNavigation extends FrameLayout {
 					anim.addListener(new Animator.AnimatorListener() {
 						@Override
 						public void onAnimationStart(Animator animation) {
+                            backgroundColorView.setVisibility(VISIBLE);
 						}
 
 						@Override
 						public void onAnimationEnd(Animator animation) {
+                            backgroundColorView.setVisibility(INVISIBLE);
 							setBackgroundColor(items.get(itemIndex).getColor(context));
 						}
 


### PR DESCRIPTION
This fixes #60 

From the issue itself:
> My assumption is that the circular reveal performed on `backgroundColorView` is covering the items' background, which is weird because `backgroundColorView` is [added as a child view](https://github.com/aurelhubert/ahbottomnavigation/blob/master/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java#L188) of `AHBottomNavigation` before the [`LinearLayout` containing the items](https://github.com/aurelhubert/ahbottomnavigation/blob/master/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java#L196)

The proposed solution is to show `backgroundColorView` while performing the circular reveal and hide it once finished.

I haven't dug much through the code to understand if this is the best approach to fix it, but at least it can give a hint on the problem