### PR TITLE
Ability to determine whether or not the click should be granted.

### DIFF
--- a/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
+++ b/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
@@ -1174,7 +1174,7 @@ public class AHBottomNavigation extends FrameLayout {
 	 * @param activeMargin
 	 * @param inactiveMargin
 	 */
-	public void setNotificationMarginLef(int activeMargin, int inactiveMargin) {
+	public void setNotificationMarginLeft(int activeMargin, int inactiveMargin) {
 		this.notificationActiveMarginLeft = activeMargin;
 		this.notificationInactiveMarginLeft = inactiveMargin;
 		createItems();

--- a/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
+++ b/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
@@ -451,6 +451,12 @@ public class AHBottomNavigation extends FrameLayout {
 			return;
 		}
 
+		if (tabSelectedListener != null) {
+			boolean selectionAllowed = tabSelectedListener.onTabSelected(itemIndex, false);
+			if (!selectionAllowed) return;
+		}
+
+
 		int activeMarginTop = (int) resources.getDimension(R.dimen.bottom_navigation_margin_top_active);
 		int inactiveMarginTop = (int) resources.getDimension(R.dimen.bottom_navigation_margin_top_inactive);
 		float activeSize = resources.getDimension(R.dimen.bottom_navigation_text_size_active);
@@ -563,6 +569,11 @@ public class AHBottomNavigation extends FrameLayout {
 				tabSelectedListener.onTabSelected(itemIndex, true);
 			}
 			return;
+		}
+
+		if (tabSelectedListener != null) {
+			boolean selectionAllowed = tabSelectedListener.onTabSelected(itemIndex, false);
+			if (!selectionAllowed) return;
 		}
 
 		int activeMarginTop = (int) resources.getDimension(R.dimen.bottom_navigation_small_margin_top_active);
@@ -1188,7 +1199,7 @@ public class AHBottomNavigation extends FrameLayout {
 	 *
 	 */
 	public interface OnTabSelectedListener {
-		void onTabSelected(int position, boolean wasSelected);
+		boolean onTabSelected(int position, boolean wasSelected);
 	}
 
 }

--- a/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
+++ b/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
@@ -30,6 +30,8 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import com.aurelhubert.ahbottomnavigation.AHBottomNavigationBehavior.OnYTranslationListener;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,7 +39,8 @@ import java.util.List;
  * AHBottomNavigationLayout
  * Material Design guidelines : https://www.google.com/design/spec/components/bottom-navigation.html
  */
-public class AHBottomNavigation extends FrameLayout {
+public class AHBottomNavigation extends FrameLayout implements
+		OnYTranslationListener {
 
 	// Constant
 	public static final int CURRENT_ITEM_NONE = -1;
@@ -50,6 +53,7 @@ public class AHBottomNavigation extends FrameLayout {
 
 	// Listener
 	private OnTabSelectedListener tabSelectedListener;
+	private AHBottomNavigationBehavior.OnYTranslationListener yTranslationListener;
 
 	// Variables
 	private Context context;
@@ -977,6 +981,8 @@ public class AHBottomNavigation extends FrameLayout {
 			} else {
 				bottomNavigationBehavior.setBehaviorTranslationEnabled(behaviorTranslationEnabled);
 			}
+
+			bottomNavigationBehavior.setYTranslationListener(this);
 			((CoordinatorLayout.LayoutParams) params).setBehavior(bottomNavigationBehavior);
 			if (needHideBottomNavigation) {
 				needHideBottomNavigation = false;
@@ -1090,6 +1096,20 @@ public class AHBottomNavigation extends FrameLayout {
 	 */
 	public void removeOnTabSelectedListener() {
 		this.tabSelectedListener = null;
+	}
+
+	/**
+	 * Set AHOnYTranslationListener
+	 */
+	public void setOnYTranslationListner(OnYTranslationListener yTranslationListener) {
+		this.yTranslationListener = yTranslationListener;
+	}
+
+	/**
+	 * Remove AHOnYTranslationListener()
+	 */
+	public void removeOnYTranslationListener() {
+		this.yTranslationListener = null;
 	}
 
 	/**
@@ -1211,6 +1231,14 @@ public class AHBottomNavigation extends FrameLayout {
 		setClipToPadding(false);
 	}
 
+
+	@Override public void onYTranslation(int y) {
+		if (yTranslationListener != null) {
+			yTranslationListener.onYTranslation(y);
+		}
+	}
+
+
 	////////////////
 	// INTERFACES //
 	////////////////
@@ -1221,5 +1249,4 @@ public class AHBottomNavigation extends FrameLayout {
 	public interface OnTabSelectedListener {
 		boolean onTabSelected(int position, boolean wasSelected);
 	}
-
 }

--- a/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigationBehavior.java
+++ b/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigationBehavior.java
@@ -37,6 +37,7 @@ public class AHBottomNavigationBehavior<V extends View> extends VerticalScrollin
 	private boolean fabBottomMarginInitialized = false;
 	private float targetOffset = 0, fabTargetOffset = 0, fabDefaultBottomMargin = 0, snackBarY = 0;
 	private boolean behaviorTranslationEnabled = true;
+	private OnYTranslationListener yTranslationListener;
 
 	/**
 	 * Constructor
@@ -179,6 +180,10 @@ public class AHBottomNavigationBehavior<V extends View> extends VerticalScrollin
 						p.setMargins(p.leftMargin, p.topMargin, p.rightMargin, (int) fabTargetOffset);
 						floatingActionButton.requestLayout();
 					}
+
+					if (yTranslationListener != null) {
+						yTranslationListener.onYTranslation((int) (-view.getTranslationY() + snackBarY));
+					}
 				}
 			});
 			translationAnimator.setInterpolator(INTERPOLATOR);
@@ -218,6 +223,10 @@ public class AHBottomNavigationBehavior<V extends View> extends VerticalScrollin
 					p.setMargins(p.leftMargin, p.topMargin, p.rightMargin, (int) fabTargetOffset);
 					floatingActionButton.requestLayout();
 				}
+
+				if (yTranslationListener != null) {
+					yTranslationListener.onYTranslation((int) (-child.getTranslationY() + snackBarY));
+				}
 			}
 		});
 	}
@@ -247,6 +256,13 @@ public class AHBottomNavigationBehavior<V extends View> extends VerticalScrollin
 	 */
 	public void setBehaviorTranslationEnabled(boolean behaviorTranslationEnabled) {
 		this.behaviorTranslationEnabled = behaviorTranslationEnabled;
+	}
+
+	/**
+	 * Add listener for y translation
+	 */
+	public void setYTranslationListener(OnYTranslationListener yTranslationListener) {
+		this.yTranslationListener = yTranslationListener;
 	}
 
 	/**
@@ -292,6 +308,10 @@ public class AHBottomNavigationBehavior<V extends View> extends VerticalScrollin
 							fabTargetOffset = fabDefaultBottomMargin - child.getTranslationY() + snackBarY;
 							p.setMargins(p.leftMargin, p.topMargin, p.rightMargin, (int) fabTargetOffset);
 							floatingActionButton.requestLayout();
+
+							if (yTranslationListener != null) {
+								yTranslationListener.onYTranslation((int) (-child.getTranslationY() + snackBarY));
+							}
 						}
 					}
 				});
@@ -327,4 +347,9 @@ public class AHBottomNavigationBehavior<V extends View> extends VerticalScrollin
 			}
 		}
 	}
+
+	public interface OnYTranslationListener {
+		void onYTranslation(int y);
+	}
+
 }

--- a/demo/src/main/java/com/aurelhubert/ahbottomnavigation/demo/DemoActivity.java
+++ b/demo/src/main/java/com/aurelhubert/ahbottomnavigation/demo/DemoActivity.java
@@ -64,7 +64,7 @@ public class DemoActivity extends AppCompatActivity {
 				currentFragment = adapter.getCurrentFragment();
 				if (wasSelected) {
 					currentFragment.refresh();
-					return;
+					return true;
 				}
 				viewPager.setCurrentItem(position, false);
 				currentFragment.willBeDisplayed();

--- a/demo/src/main/java/com/aurelhubert/ahbottomnavigation/demo/DemoActivity.java
+++ b/demo/src/main/java/com/aurelhubert/ahbottomnavigation/demo/DemoActivity.java
@@ -59,7 +59,7 @@ public class DemoActivity extends AppCompatActivity {
 
 		bottomNavigation.setOnTabSelectedListener(new AHBottomNavigation.OnTabSelectedListener() {
 			@Override
-			public void onTabSelected(int position, boolean wasSelected) {
+			public boolean onTabSelected(int position, boolean wasSelected) {
 
 				if (position == 1) {
 					bottomNavigation.setNotification("", 1);
@@ -142,6 +142,7 @@ public class DemoActivity extends AppCompatActivity {
 				} else if (position > 0) {
 					currentFragment.refresh();
 				}
+				return true;
 			}
 		});
 


### PR DESCRIPTION
I realize this will force a change for everyone for the onTabSelectedListener by having to specify the return type, however, this method does have it's advantages. Feel free to reject or propose an alternate solution.

I had to make this change for a project I'm working on because some of the app isn't functional before a successful login. We still wanted to show new users what the app has to offer, however, when a user clicks on a tab that requires login, I then throw up a Sign-In/Sign-Up DialogFragment. Because the user was not actually redirected to the selected tab, I did not want to update the navigation bar. By returning false in onTabSelected, it prevents the tab selection from occurring.