### PR TITLE
Fix compilation error

### DIFF
--- a/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
+++ b/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
@@ -71,11 +71,12 @@ public class AHBottomNavigation extends FrameLayout {
 	// Variables (Styles)
 	private Typeface titleTypeface;
 	private int defaultBackgroundColor = Color.WHITE;
-	//private int accentColor = Color.WHITE;
-	//private int inactiveColor = Color.WHITE;
-	private @ColorInt int itemActiveColor, itemInactiveColor;
-	private @ColorInt int titleColorActive, titleColorInactive;
-	private @ColorInt int coloredTitleColorActive, coloredTitleColorInactive;
+	private @ColorInt int itemActiveColor;
+	private @ColorInt int itemInactiveColor;
+	private @ColorInt int titleColorActive;
+	private @ColorInt int titleColorInactive;
+	private @ColorInt int coloredTitleColorActive;
+	private @ColorInt int coloredTitleColorInactive;
 	private float titleActiveTextSize, titleInactiveTextSize;
 	private int bottomNavigationHeight;
 	private float selectedItemWidth, notSelectedItemWidth;


### PR DESCRIPTION
I got this error while building this library inline in AOSP tree (CyanogenMod):

com.android.sched.scheduler.RunnerProcessException: Error during 'FieldAnnotationBuilder' runner on
    'private int com.aurelhubert.ahbottomnavigation.AHBottomNavigation.itemActiveColor
    (/home/mike/android/cm-13.0/external/ahbottomnavigation/ahbottomnavigation/src/main/java/
    com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java:76.24-76.38)':
    duplicate type: android.support.annotation.ColorInt