### PR TITLE
Notification animates margin top in order to stick to the tab icon

### DIFF
--- a/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
+++ b/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
@@ -88,6 +88,7 @@ public class AHBottomNavigation extends FrameLayout {
 	private Drawable notificationBackgroundDrawable;
 	private Typeface notificationTypeface;
 	private int notificationActiveMarginLeft, notificationInactiveMarginLeft;
+	private int notificationActiveMarginTop, notificationInactiveMarginTop;
 
 	/**
 	 * Constructors
@@ -172,6 +173,8 @@ public class AHBottomNavigation extends FrameLayout {
 		// Notifications
 		notificationActiveMarginLeft = (int) resources.getDimension(R.dimen.bottom_navigation_notification_margin_left_active);
 		notificationInactiveMarginLeft = (int) resources.getDimension(R.dimen.bottom_navigation_notification_margin_left);
+		notificationActiveMarginTop = (int) resources.getDimension(R.dimen.bottom_navigation_notification_margin_top_active);
+		notificationInactiveMarginTop = (int) resources.getDimension(R.dimen.bottom_navigation_notification_margin_top);
 
 		ViewCompat.setElevation(this, resources.getDimension(R.dimen.bottom_navigation_elevation));
 		setClipToPadding(false);
@@ -401,7 +404,7 @@ public class AHBottomNavigation extends FrameLayout {
 
 					ViewGroup.MarginLayoutParams paramsNotification = (ViewGroup.MarginLayoutParams)
 							notification.getLayoutParams();
-					paramsNotification.setMargins(notificationActiveMarginLeft, paramsNotification.topMargin,
+					paramsNotification.setMargins(notificationActiveMarginLeft, notificationActiveMarginTop,
 							paramsNotification.rightMargin, paramsNotification.bottomMargin);
 
 					view.requestLayout();
@@ -410,7 +413,7 @@ public class AHBottomNavigation extends FrameLayout {
 				icon.setSelected(false);
 				ViewGroup.MarginLayoutParams paramsNotification = (ViewGroup.MarginLayoutParams)
 						notification.getLayoutParams();
-				paramsNotification.setMargins(notificationInactiveMarginLeft, paramsNotification.topMargin,
+				paramsNotification.setMargins(notificationInactiveMarginLeft, notificationInactiveMarginTop,
 						paramsNotification.rightMargin, paramsNotification.bottomMargin);
 			}
 
@@ -590,6 +593,7 @@ public class AHBottomNavigation extends FrameLayout {
 				icon.setSelected(true);
 				AHHelper.updateTopMargin(icon, inactiveMargin, activeMarginTop);
 				AHHelper.updateLeftMargin(notification, notificationInactiveMarginLeft, notificationActiveMarginLeft);
+				AHHelper.updateTopMargin(notification, notificationInactiveMarginTop, notificationActiveMarginTop);
 				AHHelper.updateTextColor(title, itemInactiveColor, itemActiveColor);
 				AHHelper.updateAlpha(title, 0, 1);
 				AHHelper.updateWidth(container, notSelectedItemWidth, selectedItemWidth);
@@ -648,6 +652,7 @@ public class AHBottomNavigation extends FrameLayout {
 				icon.setSelected(false);
 				AHHelper.updateTopMargin(icon, activeMarginTop, inactiveMargin);
 				AHHelper.updateLeftMargin(notification, notificationActiveMarginLeft, notificationInactiveMarginLeft);
+				AHHelper.updateTopMargin(notification, notificationActiveMarginTop, notificationInactiveMarginTop);
 				AHHelper.updateTextColor(title, itemActiveColor, itemInactiveColor);
 				AHHelper.updateAlpha(title, 1, 0);
 				AHHelper.updateWidth(container, selectedItemWidth, notSelectedItemWidth);

--- a/ahbottomnavigation/src/main/res/layout/bottom_navigation_item.xml
+++ b/ahbottomnavigation/src/main/res/layout/bottom_navigation_item.xml
@@ -39,7 +39,7 @@
         android:minWidth="@dimen/bottom_navigation_notification_width"
         android:layout_gravity="center_horizontal"
         android:layout_marginLeft="@dimen/bottom_navigation_notification_margin_left"
-        android:layout_marginTop="@dimen/bottom_navigation_notification_margin_top"
+        android:layout_marginTop="@dimen/bottom_navigation_notification_margin_top_classic"
         android:paddingLeft="@dimen/bottom_navigation_notification_padding"
         android:paddingRight="@dimen/bottom_navigation_notification_padding"
         android:alpha="0"

--- a/ahbottomnavigation/src/main/res/values/dimens.xml
+++ b/ahbottomnavigation/src/main/res/values/dimens.xml
@@ -36,9 +36,11 @@
     <dimen name="bottom_navigation_notification_height">16dp</dimen>
     <dimen name="bottom_navigation_notification_radius">8dp</dimen>
     <dimen name="bottom_navigation_notification_padding">3dp</dimen>
-    <dimen name="bottom_navigation_notification_margin_top">4dp</dimen>
+    <dimen name="bottom_navigation_notification_margin_top_classic">4dp</dimen>
     <dimen name="bottom_navigation_notification_margin_left">16dp</dimen>
-    <dimen name="bottom_navigation_notification_margin_left_active">24dp</dimen>
+    <dimen name="bottom_navigation_notification_margin_left_active">16dp</dimen>
+    <dimen name="bottom_navigation_notification_margin_top">14dp</dimen>
+    <dimen name="bottom_navigation_notification_margin_top_active">3dp</dimen>
     <dimen name="bottom_navigation_notification_text_size">9sp</dimen>
 
 </resources>


### PR DESCRIPTION
Notifications for small items (where title is not always included) do not stick to the tab icon:

<img src="https://i.imgur.com/YWJPo8Q.gif" height="100px"/>

This was unacceptable for our "small items" use case. By setting the margin-top on the layout params, too, we can make the notification _follow_ the icon:

<img src="https://i.imgur.com/jeg7t8a.gif" height="100px"/>

