### PR TITLE
BottomNavigation Height Reporting

### DIFF
--- a/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
+++ b/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
@@ -50,6 +50,7 @@ public class AHBottomNavigation extends FrameLayout {
 
 	// Listener
 	private OnTabSelectedListener tabSelectedListener;
+	private OnNavigationHeightListener navigationHeightListener;
 
 	// Variables
 	private Context context;
@@ -1010,6 +1011,9 @@ public class AHBottomNavigation extends FrameLayout {
 			} else {
 				bottomNavigationBehavior.setBehaviorTranslationEnabled(behaviorTranslationEnabled);
 			}
+			if (navigationHeightListener != null) {
+				bottomNavigationBehavior.setOnNavigationHeightListener(navigationHeightListener);
+			}
 			((CoordinatorLayout.LayoutParams) params).setBehavior(bottomNavigationBehavior);
 			if (needHideBottomNavigation) {
 				needHideBottomNavigation = false;
@@ -1123,6 +1127,28 @@ public class AHBottomNavigation extends FrameLayout {
 	 */
 	public void removeOnTabSelectedListener() {
 		this.tabSelectedListener = null;
+	}
+
+	/**
+	 * Set OnNavigationHeightListener
+	 */
+	public void setOnNavigationHeightListener(OnNavigationHeightListener navigationHeightListener) {
+		this.navigationHeightListener = navigationHeightListener;
+
+		if (bottomNavigationBehavior != null) {
+			bottomNavigationBehavior.setOnNavigationHeightListener(navigationHeightListener);
+		}
+	}
+
+	/**
+	 * Remove OnNavigationHeightListener()
+	 */
+	public void removeOnNavigationHeightListener() {
+		this.navigationHeightListener = null;
+
+		if (bottomNavigationBehavior != null) {
+			bottomNavigationBehavior.removeOnNavigationHeightListener();
+		}
 	}
 
 	/**
@@ -1262,6 +1288,15 @@ public class AHBottomNavigation extends FrameLayout {
 		 * @return boolean: true for updating the tab UI, false otherwise
 		 */
 		boolean onTabSelected(int position, boolean wasSelected);
+	}
+
+	public interface OnNavigationHeightListener {
+		/**
+		 * Called when the bottom navigation height is changed
+		 *
+		 * @param height    int: height of bottom navigation
+		 */
+		void onHeightChange(int height);
 	}
 
 }

--- a/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigationBehavior.java
+++ b/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigationBehavior.java
@@ -18,6 +18,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.Interpolator;
 
+import com.aurelhubert.ahbottomnavigation.AHBottomNavigation.OnNavigationHeightListener;
+
 /**
  *
  */
@@ -37,6 +39,7 @@ public class AHBottomNavigationBehavior<V extends View> extends VerticalScrollin
 	private boolean fabBottomMarginInitialized = false;
 	private float targetOffset = 0, fabTargetOffset = 0, fabDefaultBottomMargin = 0, snackBarY = 0;
 	private boolean behaviorTranslationEnabled = true;
+	private OnNavigationHeightListener navigationHeightListener;
 
 	/**
 	 * Constructor
@@ -179,6 +182,10 @@ public class AHBottomNavigationBehavior<V extends View> extends VerticalScrollin
 						p.setMargins(p.leftMargin, p.topMargin, p.rightMargin, (int) fabTargetOffset);
 						floatingActionButton.requestLayout();
 					}
+					// Pass navigation height to listener
+					if (navigationHeightListener != null) {
+						navigationHeightListener.onHeightChange((int) (view.getMeasuredHeight() - view.getTranslationY() + snackBarY));
+					}
 				}
 			});
 			translationAnimator.setInterpolator(INTERPOLATOR);
@@ -218,6 +225,10 @@ public class AHBottomNavigationBehavior<V extends View> extends VerticalScrollin
 					p.setMargins(p.leftMargin, p.topMargin, p.rightMargin, (int) fabTargetOffset);
 					floatingActionButton.requestLayout();
 				}
+				// Pass navigation height to listener
+				if (navigationHeightListener != null) {
+					navigationHeightListener.onHeightChange((int) (child.getMeasuredHeight() - child.getTranslationY() + snackBarY));
+				}
 			}
 		});
 	}
@@ -247,6 +258,20 @@ public class AHBottomNavigationBehavior<V extends View> extends VerticalScrollin
 	 */
 	public void setBehaviorTranslationEnabled(boolean behaviorTranslationEnabled) {
 		this.behaviorTranslationEnabled = behaviorTranslationEnabled;
+	}
+
+	/**
+	 * Set OnNavigationHeightListener
+	 */
+	public void setOnNavigationHeightListener(OnNavigationHeightListener navigationHeightListener) {
+		this.navigationHeightListener = navigationHeightListener;
+	}
+
+	/**
+	 * Remove OnNavigationHeightListener()
+	 */
+	public void removeOnNavigationHeightListener() {
+		this.navigationHeightListener = null;
 	}
 
 	/**
@@ -292,6 +317,10 @@ public class AHBottomNavigationBehavior<V extends View> extends VerticalScrollin
 							fabTargetOffset = fabDefaultBottomMargin - child.getTranslationY() + snackBarY;
 							p.setMargins(p.leftMargin, p.topMargin, p.rightMargin, (int) fabTargetOffset);
 							floatingActionButton.requestLayout();
+						}
+						// Pass navigation height to listener
+						if (navigationHeightListener != null) {
+							navigationHeightListener.onHeightChange((int) (child.getMeasuredHeight() - child.getTranslationY() + snackBarY));
 						}
 					}
 				});

--- a/demo/src/main/java/com/aurelhubert/ahbottomnavigation/demo/DemoActivity.java
+++ b/demo/src/main/java/com/aurelhubert/ahbottomnavigation/demo/DemoActivity.java
@@ -62,6 +62,7 @@ public class DemoActivity extends AppCompatActivity {
 			@Override
 			public boolean onTabSelected(int position, boolean wasSelected) {
 
+				currentFragment = adapter.getCurrentFragment();
 				if (wasSelected) {
 					currentFragment.refresh();
 					return true;
@@ -72,7 +73,6 @@ public class DemoActivity extends AppCompatActivity {
 				}
 
 				viewPager.setCurrentItem(position, false);
-				currentFragment = adapter.getCurrentFragment();
 				currentFragment.willBeDisplayed();
 
 				if (position == 1) {

--- a/demo/src/main/java/com/aurelhubert/ahbottomnavigation/demo/DemoActivity.java
+++ b/demo/src/main/java/com/aurelhubert/ahbottomnavigation/demo/DemoActivity.java
@@ -9,6 +9,7 @@ import android.support.design.widget.Snackbar;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.animation.LinearOutSlowInInterpolator;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.view.View;
 import android.view.animation.OvershootInterpolator;
 
@@ -146,6 +147,12 @@ public class DemoActivity extends AppCompatActivity {
 				}
 
 				return true;
+			}
+		});
+
+		bottomNavigation.setOnNavigationHeightListener(new AHBottomNavigation.OnNavigationHeightListener() {
+			@Override public void onHeightChange(int height) {
+				Log.d("DemoActivity", "BottomNavigation Height: " + height);
 			}
 		});
 


### PR DESCRIPTION
I ended up rewriting this a bit. Rather than showing the -y offset from the initial bottom navigation height, I have created a height listener that will update with the bottom navigation height.

If the -y offset is desired, just do: 
```
@Override public void onHeightChange(int height) {
  int yOffset = height - defaultHeight
}
```

I also fixed a npe where currentFragment was null when called