### PR TITLE
add optional selected item background

### DIFF
--- a/ahbottomnavigation/src/main/res/drawable-v21/item_background.xml
+++ b/ahbottomnavigation/src/main/res/drawable-v21/item_background.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <selector>
+            <item android:state_selected="true" android:drawable="@color/colorBottomNavigationSelectedBackground" />
+            <item android:drawable="@android:color/transparent" />
+        </selector>
+    </item>
+    <item android:drawable="?attr/selectableItemBackgroundBorderless" />
+</layer-list>

--- a/ahbottomnavigation/src/main/res/drawable/item_background.xml
+++ b/ahbottomnavigation/src/main/res/drawable/item_background.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- Even though these two point to the same resource, have two states so the drawable will invalidate itself when coming out of pressed state. -->
+    <item android:state_focused="true"  android:state_enabled="false" android:state_pressed="true" android:drawable="@drawable/abc_list_selector_disabled_holo_dark" />
+    <item android:state_focused="true"  android:state_enabled="false"                              android:drawable="@drawable/abc_list_selector_disabled_holo_dark" />
+    <item android:state_focused="true"                                android:state_pressed="true" android:drawable="@drawable/abc_list_selector_background_transition_holo_dark" />
+    <item android:state_focused="false"                               android:state_pressed="true" android:drawable="@drawable/abc_list_selector_background_transition_holo_dark" />
+    <item android:state_focused="true"                                                             android:drawable="@drawable/abc_list_focused_holo" />
+    <item android:state_selected="true"                                                            android:drawable="@color/colorBottomNavigationSelectedBackground" />
+    <item                                                                                          android:drawable="@android:color/transparent" />
+</selector>

--- a/ahbottomnavigation/src/main/res/layout/bottom_navigation_item.xml
+++ b/ahbottomnavigation/src/main/res/layout/bottom_navigation_item.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/bottom_navigation_height"
-    android:background="?selectableItemBackgroundBorderless"
+    android:background="@drawable/item_background"
     android:minWidth="@dimen/bottom_navigation_min_width"
     android:paddingLeft="@dimen/bottom_navigation_padding_left"
     android:paddingRight="@dimen/bottom_navigation_padding_right">

--- a/ahbottomnavigation/src/main/res/layout/bottom_navigation_small_item.xml
+++ b/ahbottomnavigation/src/main/res/layout/bottom_navigation_small_item.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/bottom_navigation_height"
-    android:background="?selectableItemBackgroundBorderless"
+    android:background="@drawable/item_background"
     android:minWidth="@dimen/bottom_navigation_min_width">
 
     <ImageView

--- a/ahbottomnavigation/src/main/res/values/attrs.xml
+++ b/ahbottomnavigation/src/main/res/values/attrs.xml
@@ -2,5 +2,6 @@
 <resources>
     <declare-styleable name="AHBottomNavigationBehavior_Params">
         <attr name="tabLayoutId" format="reference" />
+        <attr name="selectedBackgroundVisible" format="boolean" />
     </declare-styleable>
 </resources>

--- a/ahbottomnavigation/src/main/res/values/colors.xml
+++ b/ahbottomnavigation/src/main/res/values/colors.xml
@@ -6,5 +6,6 @@
     <color name="colorBottomNavigationInactive">#747474</color>
     <color name="colorBottomNavigationActiveColored">#FFFFFF</color>
     <color name="colorBottomNavigationInactiveColored">#50FFFFFF</color>
+    <color name="colorBottomNavigationSelectedBackground">#17000000</color>
     <color name="colorBottomNavigationNotification">#F63D2B</color>
 </resources>

--- a/demo/src/main/java/com/aurelhubert/ahbottomnavigation/demo/DemoActivity.java
+++ b/demo/src/main/java/com/aurelhubert/ahbottomnavigation/demo/DemoActivity.java
@@ -66,9 +66,6 @@ public class DemoActivity extends AppCompatActivity {
 			bottomNavigation.addItems(bottomNavigationItems);
 		}
 
-		bottomNavigation.setAccentColor(Color.parseColor("#F63D2B"));
-		bottomNavigation.setInactiveColor(Color.parseColor("#747474"));
-
 		bottomNavigation.setOnTabSelectedListener(new AHBottomNavigation.OnTabSelectedListener() {
 			@Override
 			public boolean onTabSelected(int position, boolean wasSelected) {
@@ -216,23 +213,23 @@ public class DemoActivity extends AppCompatActivity {
 				navigationAdapter = new AHBottomNavigationAdapter(this, R.menu.bottom_navigation_menu_3);
 				navigationAdapter.setupWithBottomNavigation(bottomNavigation, tabColors);
 			}
-			return;
-		}
 
-		AHBottomNavigationItem item4 = new AHBottomNavigationItem(getString(R.string.tab_4),
-				ContextCompat.getDrawable(this, R.drawable.ic_maps_local_bar),
-				ContextCompat.getColor(this, R.color.color_tab_4));
-		AHBottomNavigationItem item5 = new AHBottomNavigationItem(getString(R.string.tab_5),
-				ContextCompat.getDrawable(this, R.drawable.ic_maps_place),
-				ContextCompat.getColor(this, R.color.color_tab_5));
-
-		if (addItems) {
-			bottomNavigation.addItem(item4);
-			bottomNavigation.addItem(item5);
-			bottomNavigation.setNotification("1", 3);
 		} else {
-			bottomNavigation.removeAllItems();
-			bottomNavigation.addItems(bottomNavigationItems);
+			if (addItems) {
+				AHBottomNavigationItem item4 = new AHBottomNavigationItem(getString(R.string.tab_4),
+						ContextCompat.getDrawable(this, R.drawable.ic_maps_local_bar),
+						ContextCompat.getColor(this, R.color.color_tab_4));
+				AHBottomNavigationItem item5 = new AHBottomNavigationItem(getString(R.string.tab_5),
+						ContextCompat.getDrawable(this, R.drawable.ic_maps_place),
+						ContextCompat.getColor(this, R.color.color_tab_5));
+
+				bottomNavigation.addItem(item4);
+				bottomNavigation.addItem(item5);
+				bottomNavigation.setNotification("1", 3);
+			} else {
+				bottomNavigation.removeAllItems();
+				bottomNavigation.addItems(bottomNavigationItems);
+			}
 		}
 	}
 
@@ -245,6 +242,13 @@ public class DemoActivity extends AppCompatActivity {
 		} else {
 			bottomNavigation.hideBottomNavigation(true);
 		}
+	}
+
+	/**
+	 * Show or hide selected item background
+	 */
+	public void updateSelectedBackgroundVisibility(boolean isVisible) {
+		bottomNavigation.setSelectedBackgroundVisible(isVisible);
 	}
 
 	/**

--- a/demo/src/main/java/com/aurelhubert/ahbottomnavigation/demo/DemoFragment.java
+++ b/demo/src/main/java/com/aurelhubert/ahbottomnavigation/demo/DemoFragment.java
@@ -59,6 +59,7 @@ public class DemoFragment extends Fragment {
 		final SwitchCompat switchColored = (SwitchCompat) view.findViewById(R.id.fragment_demo_switch_colored);
 		final SwitchCompat switchFiveItems = (SwitchCompat) view.findViewById(R.id.fragment_demo_switch_five_items);
 		final SwitchCompat showHideBottomNavigation = (SwitchCompat) view.findViewById(R.id.fragment_demo_show_hide);
+		final SwitchCompat showSelectedBackground = (SwitchCompat) view.findViewById(R.id.fragment_demo_selected_background);
 
 		switchColored.setChecked(demoActivity.isBottomNavigationColored());
 		switchFiveItems.setChecked(demoActivity.getBottomNavigationNbItems() == 5);
@@ -79,6 +80,12 @@ public class DemoFragment extends Fragment {
 			@Override
 			public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
 				demoActivity.showOrHideBottomNavigation(isChecked);
+			}
+		});
+		showSelectedBackground.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+			@Override
+			public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+				demoActivity.updateSelectedBackgroundVisibility(isChecked);
 			}
 		});
 	}

--- a/demo/src/main/res/layout/activity_home.xml
+++ b/demo/src/main/res/layout/activity_home.xml
@@ -23,7 +23,8 @@
         android:id="@+id/bottom_navigation"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="bottom" />
+        android:layout_gravity="bottom"
+        app:selectedBackgroundVisible="false" />
 
 </android.support.design.widget.CoordinatorLayout>
 

--- a/demo/src/main/res/layout/fragment_demo_settings.xml
+++ b/demo/src/main/res/layout/fragment_demo_settings.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin"
     android:paddingTop="@dimen/activity_vertical_margin">
@@ -21,5 +22,11 @@
         style="@style/setting"
         android:checked="true"
         android:text="Show bottom navigation" />
+
+    <android.support.v7.widget.SwitchCompat
+        android:id="@+id/fragment_demo_selected_background"
+        style="@style/setting"
+        android:checked="false"
+        android:text="Show selected background" />
 
 </LinearLayout>

--- a/demo/src/main/res/layout/fragment_demo_settings.xml
+++ b/demo/src/main/res/layout/fragment_demo_settings.xml
@@ -1,69 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="24dp">
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingTop="@dimen/activity_vertical_margin">
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
+    <android.support.v7.widget.SwitchCompat
+        android:id="@+id/fragment_demo_switch_colored"
+        style="@style/setting"
+        android:text="Colored" />
 
-        <TextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="Colored"
-            android:textSize="18sp"/>
+    <android.support.v7.widget.SwitchCompat
+        android:id="@+id/fragment_demo_switch_five_items"
+        style="@style/setting"
+        android:text="5 items" />
 
-        <android.support.v7.widget.SwitchCompat
-            android:id="@+id/fragment_demo_switch_colored"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="24dp"
-        android:orientation="horizontal">
-
-        <TextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="5 items?"
-            android:textSize="18sp"/>
-
-        <android.support.v7.widget.SwitchCompat
-            android:id="@+id/fragment_demo_switch_five_items"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="24dp"
-        android:orientation="horizontal">
-
-        <TextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="Show bottom navigation"
-            android:textSize="18sp"/>
-
-        <android.support.v7.widget.SwitchCompat
-            android:id="@+id/fragment_demo_show_hide"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:checked="true"/>
-
-    </LinearLayout>
+    <android.support.v7.widget.SwitchCompat
+        android:id="@+id/fragment_demo_show_hide"
+        style="@style/setting"
+        android:checked="true"
+        android:text="Show bottom navigation" />
 
 </LinearLayout>

--- a/demo/src/main/res/values/dimens.xml
+++ b/demo/src/main/res/values/dimens.xml
@@ -1,4 +1,6 @@
 <resources>
+    <dimen name="activity_horizontal_margin">16dp</dimen>
+    <dimen name="activity_vertical_margin">16dp</dimen>
 
     <dimen name="bottom_navigation_elevation">8dp</dimen>
 

--- a/demo/src/main/res/values/styles.xml
+++ b/demo/src/main/res/values/styles.xml
@@ -8,4 +8,15 @@
         <item name="colorAccent">@color/colorAccent</item>
     </style>
 
+    <style name="setting">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:paddingTop">16dp</item>
+        <item name="android:paddingBottom">16dp</item>
+        <item name="android:paddingLeft">@dimen/activity_horizontal_margin</item>
+        <item name="android:paddingRight">@dimen/activity_horizontal_margin</item>
+        <item name="android:textSize">18sp</item>
+        <item name="android:textColor">?android:textColorSecondary</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Resolve #127 by add an optional selected item background.

It's against the material guidelines so to enable it add `selectedBackgroundVisible` attribute to `AHBottomNavigation` view in layout:

    <com.aurelhubert.ahbottomnavigation.AHBottomNavigation
        android:id="@+id/bottom_nav"
        android:layout_width="match_parent"
        android:layout_height="wrap_content"
        app:selectedBackgroundVisible="true" />


or set it programatically:

    bottomNav.setSelectedBackgroundVisible(true)

You can also change color by override `colorBottomNavigationSelectedBackground` in `colors.xml` eg.

    <color name="colorBottomNavigationSelectedBackground">#f00</color>

![device-2016-08-03-195112](https://cloud.githubusercontent.com/assets/2025949/17376020/efbcfdc4-59b3-11e6-9aa7-a5f52ebb898b.png)