### PR TITLE
Add item title display state configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     }

--- a/demo/src/main/java/com/aurelhubert/ahbottomnavigation/demo/DemoActivity.java
+++ b/demo/src/main/java/com/aurelhubert/ahbottomnavigation/demo/DemoActivity.java
@@ -263,7 +263,8 @@ public class DemoActivity extends AppCompatActivity {
 	 * Show or hide selected item background
 	 */
 	public void setForceTitleHide(boolean forceTitleHide) {
-		bottomNavigation.setForceTitlesHide(forceTitleHide);
+		AHBottomNavigation.TitleState state = forceTitleHide ? AHBottomNavigation.TitleState.ALWAYS_HIDE : AHBottomNavigation.TitleState.ALWAYS_SHOW;
+		bottomNavigation.setTitleState(state);
 	}
 
 	/**


### PR DESCRIPTION
For one of my projects, I wanted to be able to hide titles at all times, similar to the Instagram bottom navigation. I feel others may desire this option as well, so I converted the boolean forceTitlesDisplay into an enum with options to:

(1) Show title when active (default)
(2) Always show
(3) Always hide

Please let me know if you have any thoughts or questions on the commit. Also, FYI, I had to upgrade gradle for Android Studio to allow me to run this project, but I left the upgrade out of this commit. Thanks for making an awesome library!
