### PR TITLE
Added option to disable FAB managing

### DIFF
--- a/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
+++ b/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
@@ -75,6 +75,7 @@ public class AHBottomNavigation extends FrameLayout {
 	private int currentItem = 0;
 	private int currentColor = 0;
 	private boolean behaviorTranslationEnabled = true;
+	private boolean floatingActionButtonTranslationEnabled = true;
 	private boolean needHideBottomNavigation = false;
 	private boolean hideBottomNavigationWithAnimation = false;
 
@@ -1114,6 +1115,7 @@ public class AHBottomNavigation extends FrameLayout {
 			} else {
 				bottomNavigationBehavior.setBehaviorTranslationEnabled(behaviorTranslationEnabled);
 			}
+			bottomNavigationBehavior.setFloatingActionButtonTranslationEnabled(floatingActionButtonTranslationEnabled);
 			if (navigationPositionListener != null) {
 				bottomNavigationBehavior.setOnNavigationPositionListener(navigationPositionListener);
 			}
@@ -1123,6 +1125,17 @@ public class AHBottomNavigation extends FrameLayout {
 				bottomNavigationBehavior.hideView(this, bottomNavigationHeight, hideBottomNavigationWithAnimation);
 				isHidden = true;
 			}
+		}
+	}
+
+	/**
+	 * Enable or not Auto handling of floating action button
+	 * @param floatingActionButtonTranslationEnabled
+     */
+	public void setFloatingActionButtonTranslationEnabled(boolean floatingActionButtonTranslationEnabled) {
+		this.floatingActionButtonTranslationEnabled = floatingActionButtonTranslationEnabled;
+		if (bottomNavigationBehavior != null) {
+			bottomNavigationBehavior.setFloatingActionButtonTranslationEnabled(floatingActionButtonTranslationEnabled);
 		}
 	}
 

--- a/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigationBehavior.java
+++ b/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigationBehavior.java
@@ -35,6 +35,7 @@ public class AHBottomNavigationBehavior<V extends View> extends VerticalScrollin
 	private TabLayout mTabLayout;
 	private Snackbar.SnackbarLayout snackbarLayout;
 	private FloatingActionButton floatingActionButton;
+	private boolean floatingActionButtonTranslationEnabled = true;
 	private int mSnackbarHeight = -1;
 	private boolean fabBottomMarginInitialized = false;
 	private float targetOffset = 0, fabTargetOffset = 0, fabDefaultBottomMargin = 0, snackBarY = 0;
@@ -260,7 +261,15 @@ public class AHBottomNavigationBehavior<V extends View> extends VerticalScrollin
 		this.behaviorTranslationEnabled = behaviorTranslationEnabled;
 	}
 
-	/**
+    /**
+     * Enable or not Auto handling of floating action button
+     * @param floatingActionButtonTranslationEnabled
+     */
+    public void setFloatingActionButtonTranslationEnabled(boolean floatingActionButtonTranslationEnabled) {
+        this.floatingActionButtonTranslationEnabled = floatingActionButtonTranslationEnabled;
+    }
+
+    /**
 	 * Set OnNavigationPositionListener
 	 */
 	public void setOnNavigationPositionListener(OnNavigationPositionListener navigationHeightListener) {
@@ -347,6 +356,10 @@ public class AHBottomNavigationBehavior<V extends View> extends VerticalScrollin
 	 * Update floating action button bottom margin
 	 */
 	public void updateFloatingActionButton(View dependency) {
+		if (!floatingActionButtonTranslationEnabled) {
+			floatingActionButton = null;
+			return;
+		}
 		if (dependency != null && dependency instanceof FloatingActionButton) {
 			floatingActionButton = (FloatingActionButton) dependency;
 			if (!fabBottomMarginInitialized && dependency.getLayoutParams() instanceof ViewGroup.MarginLayoutParams) {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.2.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     }


### PR DESCRIPTION
In my project i need to handle floating action button above an AdMob view, and the admob above the bottom navigation. If BottomNavigation handles it automatically it breaks all my behavior. 

This is just adding an option that disables handling