### PR TITLE
Hide FAB on parent scroll

### DIFF
--- a/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
+++ b/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
@@ -71,7 +71,6 @@ public class AHBottomNavigation extends FrameLayout {
 	// Listener
 	private OnTabSelectedListener tabSelectedListener;
 	private OnNavigationPositionListener navigationPositionListener;
-	private OnVisibilityChangeListener visibilityChangeListener;
 
 	// Variables
 	private Context context;
@@ -1212,10 +1211,32 @@ public class AHBottomNavigation extends FrameLayout {
 	 * @param fab Floating Action Button
 	 */
 	public void manageFloatingActionButtonBehavior(FloatingActionButton fab) {
-		if (fab.getParent() instanceof CoordinatorLayout) {
+		manageFloatingActionButtonBehavior(fab, false);
+	}
+
+	/**
+	 * Manage the floating action button behavior with AHBottomNavigation
+	 * @param fab Floating Action Button
+	 * @param hideOnScroll Boolean to hide on scroll
+	 */
+	public void manageFloatingActionButtonBehavior(final FloatingActionButton fab, boolean hideOnScroll) {
+		if (fab.getParent() instanceof CoordinatorLayout && !hideOnScroll) {
 			AHBottomNavigationFABBehavior fabBehavior = new AHBottomNavigationFABBehavior(navigationBarHeight);
-			((CoordinatorLayout.LayoutParams) fab.getLayoutParams())
-					.setBehavior(fabBehavior);
+			((CoordinatorLayout.LayoutParams) fab.getLayoutParams()).setBehavior(fabBehavior);
+		}
+
+		if (hideOnScroll) {
+			if (bottomNavigationBehavior == null) setBehaviorTranslationEnabled(true);
+			bottomNavigationBehavior.setOnVisibilityChangedListener(new AHBottomNavigationBehavior.OnVisibilityChangedListener() {
+				@Override
+				public void onVisibilityChanged(boolean isHidden) {
+					if (isHidden) {
+						fab.show();
+					} else {
+						fab.hide();
+					}
+				}
+			});
 		}
 	}
 
@@ -1246,10 +1267,6 @@ public class AHBottomNavigation extends FrameLayout {
 					.setDuration(withAnimation ? 300 : 0)
 					.start();
 		}
-		// notify the visibility of the view changed
-		if(visibilityChangeListener != null) {
-			visibilityChangeListener.onVisibilityChange(true);
-		}
 	}
 
 	/**
@@ -1275,10 +1292,6 @@ public class AHBottomNavigation extends FrameLayout {
 					.setInterpolator(new LinearOutSlowInInterpolator())
 					.setDuration(withAnimation ? 300 : 0)
 					.start();
-		}
-		// notify the visibility of the view changed
-		if (visibilityChangeListener != null) {
-			visibilityChangeListener.onVisibilityChange(false);
 		}
 	}
 
@@ -1371,20 +1384,6 @@ public class AHBottomNavigation extends FrameLayout {
 		if (bottomNavigationBehavior != null) {
 			bottomNavigationBehavior.removeOnNavigationPositionListener();
 		}
-	}
-
-	/**
-	 * Set OnVisibilityChangeListener
-	 */
-	public void setOnVisibilityChangeListener(OnVisibilityChangeListener visibilityChangeListener) {
-		this.visibilityChangeListener = visibilityChangeListener;
-	}
-
-	/**
-	 * Remove OnVisibilityChangeListener
-	 */
-	public void removeOnVisibilityChangeListener() {
-		this.visibilityChangeListener = null;
 	}
 
 	/**
@@ -1573,15 +1572,6 @@ public class AHBottomNavigation extends FrameLayout {
 		 * @param y int: y translation of bottom navigation
 		 */
 		void onPositionChange(int y);
-	}
-
-	public interface OnVisibilityChangeListener {
-		/**
-		 * Called when the bottom navigation is hidden
-		 *
-		 * @param isHidden boolean: true if it is now hidden
-		 */
-		void onVisibilityChange(boolean ishHidden);
 	}
 
 }

--- a/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
+++ b/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
@@ -71,6 +71,7 @@ public class AHBottomNavigation extends FrameLayout {
 	// Listener
 	private OnTabSelectedListener tabSelectedListener;
 	private OnNavigationPositionListener navigationPositionListener;
+	private OnVisibilityChangeListener visibilityChangeListener;
 
 	// Variables
 	private Context context;
@@ -1245,6 +1246,10 @@ public class AHBottomNavigation extends FrameLayout {
 					.setDuration(withAnimation ? 300 : 0)
 					.start();
 		}
+		// notify the visibility of the view changed
+		if(visibilityChangeListener != null) {
+			visibilityChangeListener.onVisibilityChange(true);
+		}
 	}
 
 	/**
@@ -1270,6 +1275,10 @@ public class AHBottomNavigation extends FrameLayout {
 					.setInterpolator(new LinearOutSlowInInterpolator())
 					.setDuration(withAnimation ? 300 : 0)
 					.start();
+		}
+		// notify the visibility of the view changed
+		if (visibilityChangeListener != null) {
+			visibilityChangeListener.onVisibilityChange(false);
 		}
 	}
 
@@ -1362,6 +1371,20 @@ public class AHBottomNavigation extends FrameLayout {
 		if (bottomNavigationBehavior != null) {
 			bottomNavigationBehavior.removeOnNavigationPositionListener();
 		}
+	}
+
+	/**
+	 * Set OnVisibilityChangeListener
+	 */
+	public void setOnVisibilityChangeListener(OnVisibilityChangeListener visibilityChangeListener) {
+		this.visibilityChangeListener = visibilityChangeListener;
+	}
+
+	/**
+	 * Remove OnVisibilityChangeListener
+	 */
+	public void removeOnVisibilityChangeListener() {
+		this.visibilityChangeListener = null;
 	}
 
 	/**
@@ -1550,6 +1573,15 @@ public class AHBottomNavigation extends FrameLayout {
 		 * @param y int: y translation of bottom navigation
 		 */
 		void onPositionChange(int y);
+	}
+
+	public interface OnVisibilityChangeListener {
+		/**
+		 * Called when the bottom navigation is hidden
+		 *
+		 * @param isHidden boolean: true if it is now hidden
+		 */
+		void onVisibilityChange(boolean ishHidden);
 	}
 
 }

--- a/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigationBehavior.java
+++ b/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigationBehavior.java
@@ -14,6 +14,7 @@ import android.support.v4.view.ViewPropertyAnimatorCompat;
 import android.support.v4.view.ViewPropertyAnimatorUpdateListener;
 import android.support.v4.view.animation.LinearOutSlowInInterpolator;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.Interpolator;
@@ -40,6 +41,7 @@ public class AHBottomNavigationBehavior<V extends View> extends VerticalScrollin
 	private float targetOffset = 0, fabTargetOffset = 0, fabDefaultBottomMargin = 0, snackBarY = 0;
 	private boolean behaviorTranslationEnabled = true;
 	private OnNavigationPositionListener navigationPositionListener;
+    private OnVisibilityChangedListener visibilityChangedListener;
 
 	/**
 	 * Constructor
@@ -134,9 +136,17 @@ public class AHBottomNavigationBehavior<V extends View> extends VerticalScrollin
 		if (scrollDirection == ScrollDirection.SCROLL_DIRECTION_DOWN && hidden) {
 			hidden = false;
 			animateOffset(child, 0, false, true);
+            Log.d("Behavior", "handleDirection: scrolled down");
+            if (visibilityChangedListener != null) {
+                visibilityChangedListener.onVisibilityChanged(true);
+            }
 		} else if (scrollDirection == ScrollDirection.SCROLL_DIRECTION_UP && !hidden) {
 			hidden = true;
 			animateOffset(child, child.getHeight(), false, true);
+            Log.d("Behavior", "handleDirection: scrolled up");
+            if (visibilityChangedListener != null) {
+                visibilityChangedListener.onVisibilityChanged(false);
+            }
 		}
 	}
 
@@ -256,6 +266,13 @@ public class AHBottomNavigationBehavior<V extends View> extends VerticalScrollin
 		this.navigationPositionListener = null;
 	}
 
+    /**
+     * Set OnVisibilityChangedListener
+     */
+    public void setOnVisibilityChangedListener(OnVisibilityChangedListener visibilityChangedListener) {
+        this.visibilityChangedListener = visibilityChangedListener;
+    }
+
 	/**
 	 * Hide AHBottomNavigation with animation
 	 * @param view
@@ -304,5 +321,14 @@ public class AHBottomNavigationBehavior<V extends View> extends VerticalScrollin
 			}
 		}
 	}
+
+	public interface OnVisibilityChangedListener {
+        /**
+         * Listener for hide/restore of the bottom navigation bar
+         *
+         * @param isHidden is true when the bottom nav becomes hidden
+         */
+        void onVisibilityChanged(boolean isHidden);
+    }
 
 }


### PR DESCRIPTION
With this addition, the manageFloatingActionButtonBehavior method can be used to hide/show the floating action button whenever the bottom navigation bar is shown/hidden. Additionally, it doesn't break functionality with existing code. 

This is my first contribution ever on Github, so feedback on my addition is appreciated.