### PR TITLE
Update notification icon margin along with icon size in ALWAYS_SHOW state

### DIFF
--- a/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
+++ b/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
@@ -399,6 +399,7 @@ public class AHBottomNavigation extends FrameLayout {
 				if (selectedBackgroundVisible) {
 					view.setSelected(true);
 				}
+				updateNotificationMarginForPosition(currentItem, i);
 				icon.setSelected(true);
 				// Update margins (icon & notification)
 				if (view.getLayoutParams() instanceof ViewGroup.MarginLayoutParams) {
@@ -407,16 +408,17 @@ public class AHBottomNavigation extends FrameLayout {
 
 					ViewGroup.MarginLayoutParams paramsNotification = (ViewGroup.MarginLayoutParams)
 							notification.getLayoutParams();
-					paramsNotification.setMargins(notificationActiveMarginLeft, paramsNotification.topMargin,
+					paramsNotification.setMargins(notificationActiveMarginLeft, notificationActiveMarginTop,
 							paramsNotification.rightMargin, paramsNotification.bottomMargin);
 
 					view.requestLayout();
 				}
 			} else {
+				updateNotificationMarginForPosition(currentItem, i);
 				icon.setSelected(false);
 				ViewGroup.MarginLayoutParams paramsNotification = (ViewGroup.MarginLayoutParams)
 						notification.getLayoutParams();
-				paramsNotification.setMargins(notificationInactiveMarginLeft, paramsNotification.topMargin,
+				paramsNotification.setMargins(notificationInactiveMarginLeft, notificationInactiveMarginTop,
 						paramsNotification.rightMargin, paramsNotification.bottomMargin);
 			}
 
@@ -486,7 +488,6 @@ public class AHBottomNavigation extends FrameLayout {
 		itemWidth -= difference;
 		notSelectedItemWidth = itemWidth;
 
-
 		for (int i = 0; i < items.size(); i++) {
 
 			final int itemIndex = i;
@@ -516,6 +517,7 @@ public class AHBottomNavigation extends FrameLayout {
 				}
 				icon.setSelected(true);
 				// Update margins (icon & notification)
+				updateNotificationMarginForPosition(currentItem, i);
 
 				if (titleState != TitleState.ALWAYS_HIDE) {
 					if (view.getLayoutParams() instanceof ViewGroup.MarginLayoutParams) {
@@ -531,6 +533,7 @@ public class AHBottomNavigation extends FrameLayout {
 					}
 				}
 			} else {
+				updateNotificationMarginForPosition(currentItem, i);
 				icon.setSelected(false);
 				ViewGroup.MarginLayoutParams paramsNotification = (ViewGroup.MarginLayoutParams)
 						notification.getLayoutParams();
@@ -625,9 +628,11 @@ public class AHBottomNavigation extends FrameLayout {
 				final ImageView icon = (ImageView) view.findViewById(R.id.bottom_navigation_item_icon);
 				final TextView notification = (TextView) view.findViewById(R.id.bottom_navigation_notification);
 
+				updateNotificationMarginForPosition(itemIndex, i);
 				icon.setSelected(true);
 				AHHelper.updateTopMargin(icon, inactiveMarginTop, activeMarginTop);
 				AHHelper.updateLeftMargin(notification, notificationInactiveMarginLeft, notificationActiveMarginLeft);
+				AHHelper.updateTopMargin(notification, notificationInactiveMarginTop, notificationActiveMarginTop);
 				AHHelper.updateTextColor(title, itemInactiveColor, itemActiveColor);
 				AHHelper.updateTextSize(title, inactiveSize, activeSize);
 				AHHelper.updateDrawableColor(context, items.get(itemIndex).getDrawable(context), icon,
@@ -686,9 +691,11 @@ public class AHBottomNavigation extends FrameLayout {
 				final ImageView icon = (ImageView) view.findViewById(R.id.bottom_navigation_item_icon);
 				final TextView notification = (TextView) view.findViewById(R.id.bottom_navigation_notification);
 
+				updateNotificationMarginForPosition(itemIndex, i);
 				icon.setSelected(false);
 				AHHelper.updateTopMargin(icon, activeMarginTop, inactiveMarginTop);
 				AHHelper.updateLeftMargin(notification, notificationActiveMarginLeft, notificationInactiveMarginLeft);
+				AHHelper.updateTopMargin(notification, notificationActiveMarginTop, notificationInactiveMarginTop);
 				AHHelper.updateTextColor(title, itemActiveColor, itemInactiveColor);
 				AHHelper.updateTextSize(title, activeSize, inactiveSize);
 				AHHelper.updateDrawableColor(context, items.get(currentItem).getDrawable(context), icon,
@@ -814,6 +821,7 @@ public class AHBottomNavigation extends FrameLayout {
 				final TextView notification = (TextView) view.findViewById(R.id.bottom_navigation_notification);
 
 				icon.setSelected(false);
+				updateNotificationMarginForPosition(itemIndex, i);
 
 				if (titleState != TitleState.ALWAYS_HIDE) {
 					AHHelper.updateTopMargin(icon, activeMarginTop, inactiveMargin);
@@ -856,6 +864,7 @@ public class AHBottomNavigation extends FrameLayout {
 			final AHNotification notificationItem = notifications.get(i);
 			final int currentTextColor = AHNotificationHelper.getTextColor(notificationItem, notificationTextColor);
 			final int currentBackgroundColor = AHNotificationHelper.getBackgroundColor(notificationItem, notificationBackgroundColor);
+			updateNotificationMarginForPosition(itemPosition, i);
 
 			TextView notification = (TextView) views.get(i).findViewById(R.id.bottom_navigation_notification);
 
@@ -888,6 +897,10 @@ public class AHBottomNavigation extends FrameLayout {
 								currentBackgroundColor, forceTint));
 					}
 				}
+				ViewGroup.MarginLayoutParams paramsNotification = (ViewGroup.MarginLayoutParams)
+						notification.getLayoutParams();
+				paramsNotification.setMargins(notificationInactiveMarginLeft, notificationInactiveMarginTop,
+						paramsNotification.rightMargin, paramsNotification.bottomMargin);
 			}
 
 			if (notificationItem.isEmpty() && notification.getText().length() > 0) {
@@ -918,6 +931,23 @@ public class AHBottomNavigation extends FrameLayout {
 		}
 	}
 
+	private void updateNotificationMarginForPosition(int selectedPosition, int position) {
+		switch (titleState) {
+			case ALWAYS_SHOW:
+				notificationInactiveMarginTop = (int) resources.getDimension(R.dimen.bottom_navigation_notification_margin_top_classic);
+				break;
+			case SHOW_WHEN_ACTIVE:
+				if (selectedPosition == position || items.size() == MIN_ITEMS) {
+					notificationInactiveMarginTop = (int) resources.getDimension(R.dimen.bottom_navigation_notification_margin_top_classic);
+				} else {
+					notificationInactiveMarginTop = (int) resources.getDimension(R.dimen.bottom_navigation_notification_margin_top);
+				}
+				break;
+			case ALWAYS_HIDE:
+				notificationInactiveMarginTop = (int) resources.getDimension(R.dimen.bottom_navigation_notification_margin_top);
+				break;
+		}
+	}
 
 	////////////
 	// PUBLIC //

--- a/ahbottomnavigation/src/main/res/values/dimens.xml
+++ b/ahbottomnavigation/src/main/res/values/dimens.xml
@@ -37,7 +37,7 @@
     <dimen name="bottom_navigation_notification_radius">8dp</dimen>
     <dimen name="bottom_navigation_notification_elevation">1dp</dimen>
     <dimen name="bottom_navigation_notification_padding">3dp</dimen>
-    <dimen name="bottom_navigation_notification_margin_top_classic">4dp</dimen>
+    <dimen name="bottom_navigation_notification_margin_top_classic">5dp</dimen>
     <dimen name="bottom_navigation_notification_margin_left">16dp</dimen>
     <dimen name="bottom_navigation_notification_margin_left_active">16dp</dimen>
     <dimen name="bottom_navigation_notification_margin_top">14dp</dimen>


### PR DESCRIPTION
In the previous state in ALWAYS_SHOW state the notification icon stays in the same position, while the item icon is changing it's size. To make notification icon more dynamic it can animate (change it's top margin) along with item icon. This change makes allows for this animation.
