### PR TITLE
Navigation item layouts for >= SDK 21 now use item_background drawabl…

### DIFF
--- a/ahbottomnavigation/build.gradle
+++ b/ahbottomnavigation/build.gradle
@@ -13,7 +13,7 @@ ext {
     siteUrl = 'https://github.com/aurelhubert/ahbottomnavigation'
     gitUrl = 'https://github.com/aurelhubert/ahbottomnavigation.git'
 
-    libraryVersion = '2.1.0'
+    libraryVersion = '2.1.0.1'
 
     developerId = 'aurelhubert'
     developerName = 'Aurelien Hubert'
@@ -25,12 +25,12 @@ ext {
 }
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 40
         versionName "2.1.0"
     }
@@ -43,7 +43,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:design:26.1.0'
+    compile 'com.android.support:design:27.1.1'
 }
 
 // Place it at the end of the file

--- a/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
+++ b/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHBottomNavigation.java
@@ -396,6 +396,7 @@ public class AHBottomNavigation extends FrameLayout {
 			inactiveSize = resources.getDimension(R.dimen.bottom_navigation_text_size_forced_inactive);
 		}
 
+		Drawable iconDrawable;
 		for (int i = 0; i < items.size(); i++) {
 			final boolean current = currentItem == i;
 			final int itemIndex = i;
@@ -457,7 +458,7 @@ public class AHBottomNavigation extends FrameLayout {
 			}
 			
 			title.setTextSize(TypedValue.COMPLEX_UNIT_PX, current ? activeSize : inactiveSize);
-			
+
 			if (itemsEnabledStates[i]) {
 				view.setOnClickListener(new OnClickListener() {
 					@Override
@@ -465,13 +466,15 @@ public class AHBottomNavigation extends FrameLayout {
 						updateItems(itemIndex, true);
 					}
 				});
-				icon.setImageDrawable(AHHelper.getTintDrawable(items.get(i).getDrawable(context),
-						current ? itemActiveColor : itemInactiveColor, forceTint));
+				iconDrawable = forceTint ? AHHelper.getTintDrawable(items.get(i).getDrawable(context),
+						current ? itemActiveColor : itemInactiveColor, forceTint) : items.get(i).getDrawable(context);
+				icon.setImageDrawable(iconDrawable);
 				title.setTextColor(current ? itemActiveColor : itemInactiveColor);
 				view.setSoundEffectsEnabled(soundEffectsEnabled);
 			} else {
-				icon.setImageDrawable(AHHelper.getTintDrawable(items.get(i).getDrawable(context),
-						itemDisableColor, forceTint));
+				iconDrawable = forceTint ? AHHelper.getTintDrawable(items.get(i).getDrawable(context),
+						itemDisableColor, forceTint) : items.get(i).getDrawable(context);
+				icon.setImageDrawable(iconDrawable);
 				title.setTextColor(itemDisableColor);
 			}
 
@@ -516,7 +519,7 @@ public class AHBottomNavigation extends FrameLayout {
 		itemWidth -= difference;
 		notSelectedItemWidth = itemWidth;
 
-
+		Drawable iconDrawable;
 		for (int i = 0; i < items.size(); i++) {
 
 			final int itemIndex = i;
@@ -582,8 +585,9 @@ public class AHBottomNavigation extends FrameLayout {
 			}
 
 			if (itemsEnabledStates[i]) {
-				icon.setImageDrawable(AHHelper.getTintDrawable(items.get(i).getDrawable(context),
-						currentItem == i ? itemActiveColor : itemInactiveColor, forceTint));
+				iconDrawable = forceTint ? AHHelper.getTintDrawable(items.get(i).getDrawable(context),
+						currentItem == i ? itemActiveColor : itemInactiveColor, forceTint) : items.get(i).getDrawable(context);
+				icon.setImageDrawable(iconDrawable);
 				title.setTextColor(currentItem == i ? itemActiveColor : itemInactiveColor);
 				title.setAlpha(currentItem == i ? 1 : 0);
 				view.setOnClickListener(new OnClickListener() {
@@ -594,8 +598,9 @@ public class AHBottomNavigation extends FrameLayout {
 				});
 				view.setSoundEffectsEnabled(soundEffectsEnabled);
 			} else {
-				icon.setImageDrawable(AHHelper.getTintDrawable(items.get(i).getDrawable(context),
-						itemDisableColor, forceTint));
+				iconDrawable = forceTint ? AHHelper.getTintDrawable(items.get(i).getDrawable(context),
+						itemDisableColor, forceTint) : items.get(i).getDrawable(context);
+				icon.setImageDrawable(iconDrawable);
 				title.setTextColor(itemDisableColor);
 				title.setAlpha(0);
 			}
@@ -667,8 +672,10 @@ public class AHBottomNavigation extends FrameLayout {
 				AHHelper.updateLeftMargin(notification, notificationInactiveMarginLeft, notificationActiveMarginLeft);
 				AHHelper.updateTextColor(title, itemInactiveColor, itemActiveColor);
 				AHHelper.updateTextSize(title, inactiveSize, activeSize);
-				AHHelper.updateDrawableColor(context, items.get(itemIndex).getDrawable(context), icon,
-						itemInactiveColor, itemActiveColor, forceTint);
+				if (forceTint) {
+					AHHelper.updateDrawableColor(context, items.get(itemIndex).getDrawable(context), icon,
+							itemInactiveColor, itemActiveColor, forceTint);
+				}
 
 				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && colored) {
 
@@ -728,8 +735,10 @@ public class AHBottomNavigation extends FrameLayout {
 				AHHelper.updateLeftMargin(notification, notificationActiveMarginLeft, notificationInactiveMarginLeft);
 				AHHelper.updateTextColor(title, itemActiveColor, itemInactiveColor);
 				AHHelper.updateTextSize(title, activeSize, inactiveSize);
-				AHHelper.updateDrawableColor(context, items.get(currentItem).getDrawable(context), icon,
-						itemActiveColor, itemInactiveColor, forceTint);
+				if (forceTint) {
+					AHHelper.updateDrawableColor(context, items.get(currentItem).getDrawable(context), icon,
+							itemActiveColor, itemInactiveColor, forceTint);
+				}
 			}
 		}
 
@@ -794,8 +803,10 @@ public class AHBottomNavigation extends FrameLayout {
 				}
 
 				AHHelper.updateAlpha(title, 0, 1);
-				AHHelper.updateDrawableColor(context, items.get(itemIndex).getDrawable(context), icon,
-						itemInactiveColor, itemActiveColor, forceTint);
+				if (forceTint) {
+					AHHelper.updateDrawableColor(context, items.get(itemIndex).getDrawable(context), icon,
+							itemInactiveColor, itemActiveColor, forceTint);
+				}
 
 				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && colored) {
 					int finalRadius = Math.max(getWidth(), getHeight());
@@ -861,8 +872,10 @@ public class AHBottomNavigation extends FrameLayout {
 				}
 
 				AHHelper.updateAlpha(title, 1, 0);
-				AHHelper.updateDrawableColor(context, items.get(currentItem).getDrawable(context), icon,
-						itemActiveColor, itemInactiveColor, forceTint);
+				if (forceTint) {
+					AHHelper.updateDrawableColor(context, items.get(currentItem).getDrawable(context), icon,
+							itemActiveColor, itemInactiveColor, forceTint);
+				}
 			}
 		}
 

--- a/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHHelper.java
+++ b/ahbottomnavigation/src/main/java/com/aurelhubert/ahbottomnavigation/AHHelper.java
@@ -35,7 +35,7 @@ public class AHHelper {
 	public static Drawable getTintDrawable(Drawable drawable, @ColorInt int color, boolean forceTint) {
 		if (forceTint) {
 			drawable.clearColorFilter();
-			drawable.setColorFilter(color, PorterDuff.Mode.SRC_IN);
+			drawable.mutate().setColorFilter(color, PorterDuff.Mode.SRC_IN);
 			drawable.invalidateSelf();
 			return drawable;
 		}
@@ -174,17 +174,19 @@ public class AHHelper {
 	public static void updateDrawableColor(final Context context, final Drawable drawable,
 	                                       final ImageView imageView, @ColorInt int fromColor,
 	                                       @ColorInt int toColor, final boolean forceTint) {
-		ValueAnimator colorAnimation = ValueAnimator.ofObject(new ArgbEvaluator(), fromColor, toColor);
-		colorAnimation.setDuration(150);
-		colorAnimation.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
-			@Override
-			public void onAnimationUpdate(ValueAnimator animator) {
-				imageView.setImageDrawable(AHHelper.getTintDrawable(drawable,
-						(Integer) animator.getAnimatedValue(), forceTint));
-				imageView.requestLayout();
-			}
-		});
-		colorAnimation.start();
+		if (forceTint) {
+			ValueAnimator colorAnimation = ValueAnimator.ofObject(new ArgbEvaluator(), fromColor, toColor);
+			colorAnimation.setDuration(150);
+			colorAnimation.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
+				@Override
+				public void onAnimationUpdate(ValueAnimator animator) {
+					imageView.setImageDrawable(AHHelper.getTintDrawable(drawable,
+							(Integer) animator.getAnimatedValue(), forceTint));
+					imageView.requestLayout();
+				}
+			});
+			colorAnimation.start();
+		}
 	}
 
 	/**

--- a/ahbottomnavigation/src/main/res/layout-v21/bottom_navigation_item.xml
+++ b/ahbottomnavigation/src/main/res/layout-v21/bottom_navigation_item.xml
@@ -5,7 +5,7 @@
     android:id="@+id/bottom_navigation_container"
     android:layout_width="match_parent"
     android:layout_height="@dimen/bottom_navigation_height"
-    android:background="?selectableItemBackgroundBorderless"
+    android:background="@drawable/item_background"
     android:minWidth="@dimen/bottom_navigation_min_width"
     android:paddingLeft="@dimen/bottom_navigation_padding_left"
     android:paddingRight="@dimen/bottom_navigation_padding_right">

--- a/ahbottomnavigation/src/main/res/layout-v21/bottom_navigation_small_item.xml
+++ b/ahbottomnavigation/src/main/res/layout-v21/bottom_navigation_small_item.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/bottom_navigation_height"
-    android:background="?selectableItemBackgroundBorderless"
+    android:background="@drawable/item_background"
     android:minWidth="@dimen/bottom_navigation_min_width">
 
     <ImageView

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
@@ -17,6 +18,7 @@ allprojects {
         maven {
             url "https://maven.google.com"
         }
+        google()
     }
 }
 


### PR DESCRIPTION
…e for background.

Hello :)

I've changed the background for the SDK 21+ layouts to use the project's item_background drawable rather than the platform selectableItemBackgroundBorderless. This is to fix an issue where when selected, the background colour would not change. I could reproduce this in the demo project as well as my own.

Thanks!